### PR TITLE
Use cbm over ef

### DIFF
--- a/bokeh_implementations/lso_dos_data/calculate-max-bandgap.py
+++ b/bokeh_implementations/lso_dos_data/calculate-max-bandgap.py
@@ -5,6 +5,7 @@ csv_file = os.path.join("datasets", "data_luc", "CombinedHDPinfo_lsodos.csv")
 
 df = pd.read_csv(csv_file)
 
-max_bandgap = df["bandgap"].max()
+max_conduction_band_minimum = df["CBM"].max()
 
-print("Largest bandgap:", max_bandgap, "eV")
+print(f"Maximum conduction band minimum (CBM) across all materials: {max_conduction_band_minimum:.5f} eV")
+

--- a/bokeh_implementations/lso_dos_data/create_bandgap_csv.py
+++ b/bokeh_implementations/lso_dos_data/create_bandgap_csv.py
@@ -4,7 +4,7 @@ import os
 path = os.path.join("datasets", "data_luc", "CombinedHDPinfo_lsodos.csv")
 df = pd.read_csv(path)
 
-subset = df[["comp", "bandgap"]].copy()
+subset = df[["comp", "bandgap", "CBM"]].copy()
 
 subset = subset.rename(columns={"comp": "material"})
 

--- a/bokeh_implementations/lso_dos_data/generate_datasets/generate_interpolated_dataset_high_value_cutoff.py
+++ b/bokeh_implementations/lso_dos_data/generate_datasets/generate_interpolated_dataset_high_value_cutoff.py
@@ -18,10 +18,10 @@ for fname in file_list:
     energies = np.array(data["tdos"]["energies"], dtype=float)
     emin_global = min(emin_global, energies.min())
 
-MAXIMUM_BANDGAP_ACROSS_MATERIALS = 9.82035
+CONDUCTION_BAND_MINIMUM_ACROSS_ALL_MATERIALS = 9.80837
 
 
-emax_global = MAXIMUM_BANDGAP_ACROSS_MATERIALS + 10
+emax_global = CONDUCTION_BAND_MINIMUM_ACROSS_ALL_MATERIALS + 5.0
 
 print(f"Global energy range: {emin_global:.3f} eV → {emax_global:.3f} eV")
 
@@ -60,7 +60,7 @@ df = pd.DataFrame(rows, columns=colnames)
 
 output_dir = os.path.join("datasets", "output")
 os.makedirs(output_dir, exist_ok=True)
-out_file = os.path.join(output_dir, "dos_dataset_interpolated_10_ev_cutoff_after_bandgap.csv")
+out_file = os.path.join(output_dir, "dos_dataset_interpolated_5_ev_cutoff_after_bandgap.csv")
 df.to_csv(out_file, index=False)
 
 print("Final shape:", df.shape)

--- a/bokeh_implementations/lso_dos_data/umap_data.py
+++ b/bokeh_implementations/lso_dos_data/umap_data.py
@@ -13,7 +13,7 @@ from bokeh.palettes import Viridis256
 
 import os
 
-csv_file = os.path.join("datasets", "output", "dos_dataset_interpolated_10_ev_cutoff_after_bandgap.csv")
+csv_file = os.path.join("datasets", "output", "dos_dataset_interpolated_5_ev_cutoff_after_bandgap.csv")
 bandgap_csv_file = os.path.join("datasets", "output", "material_bandgap.csv")
 
 dos_df = pd.read_csv(csv_file)
@@ -43,7 +43,7 @@ print("finished UMAP")
 SAVING_DIR = os.path.join("bokehfiles")
 os.makedirs(SAVING_DIR, exist_ok=True)
 
-FILE_NAME = f"dos_sparse_umap_10ev_after_bandgap_{N_NEIGHBORS}_neighbors_{DISTANCE_METRIC}.html"
+FILE_NAME = f"dos_sparse_umap_5ev_after_bandgap_{N_NEIGHBORS}_neighbors_{DISTANCE_METRIC}.html"
 
 MATERIAL_STRING = "material"
 X_AXIS_STRING = "x"


### PR DESCRIPTION
This pull request updates the data preparation and analysis scripts to use the conduction band minimum (CBM) instead of the bandgap for certain calculations, and changes the energy cutoff from 10 eV to 5 eV above the CBM in the interpolated dataset and UMAP analysis. The changes ensure consistency in how the upper energy limit is determined and reflected in filenames and outputs.

